### PR TITLE
Change theme_use to return active theme name if no args to implement #6

### DIFF
--- a/tests/test_themed_style.py
+++ b/tests/test_themed_style.py
@@ -27,4 +27,4 @@ class TestThemedStyle(unittest.TestCase):
         for item in themes:
             self.assertTrue(item in style.themes)
             style.theme_use(item)
-        self.assertEqual(style.theme_use, style.set_theme)
+            self.assertEqual(style.theme_use(), item)

--- a/ttkthemes/themed_style.py
+++ b/ttkthemes/themed_style.py
@@ -30,8 +30,17 @@ class ThemedStyle(ttk.Style):
         self.tk.eval("source themes/pkgIndex.tcl")
         os.chdir(prev_folder)
 
-        self.theme_use = self.set_theme
         self.theme_names = self.get_themes
+
+    def theme_use(self, theme_name=None):
+        if theme_name is None:
+            # return currently used theme
+            # this also works on python 2 because ttk.Style inherits
+            # from object
+            return super(ThemedStyle, self).theme_use()
+
+        self.set_theme(theme_name)
+        return None
 
     def set_theme(self, theme_name):
         self.tk.call("package", "require", "ttkthemes")


### PR DESCRIPTION
Now `style.theme_use()` can be also called without any arguments to check which theme is currently being used. Previously this worked with plain ttk, but not with ttkthemes:

```python
>>> from tkinter import ttk
>>> import ttkthemes
>>> ttk.Style().theme_use()
'default'
>>> ttkthemes.ThemedStyle().theme_use()
Traceback (most recent call last):
  ...
TypeError: set_theme() missing 1 required positional argument: 'theme_name'
>>>
```