### PR TITLE
Merge setup into master to fix two CI issues

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,6 +10,7 @@ environment:
     - PYTHON: "C:\\PYTHON36-x64"
 install:
   - "%PYTHON%\\python.exe -m pip install codecov coverage nose"
+  - "%PYTHON%\\python.exe -m pip install setuptools --upgrade"
 build: off
 test_script:
   - "%PYTHON%\\python.exe setup.py install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 required: sudo
+dist: precise
 python:
     - "2.7"
     - "3.5"


### PR DESCRIPTION
This PR addresses two separate issues:
- Travis-CI's updated images for Ubuntu cause issues with Tkinter for an as of now unkown reason. The change to `.travis.yml` will make sure the builds run on the now legacy precise environment.
- AppVeyor's Python 3.4 environment uses an old version of `setuptools` that did not provide support for the changes made in 10a540f. Now the setuptools version of the environment is updated before installing the package.