### PR TITLE
Fix critical #26 by changing directory checked in setup.py

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,7 +12,7 @@ build: off
 test_script:
   - "%PYTHON%\\python.exe ci.py"
 artifacts:
-  - path: "dist\\*.whl"
+  - path: "/dist/.*.whl"
 deploy:
   provider: GitHub
   auth_token:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
   - os: linux
     python: '3.6'
     env: PYTHON=python NUMBER="36" OS="linux"
+  - os: linux
+    python: '3.6'
+    env: PYTHON=python NUMBER="36" OS="linux" SDIST="true"
   - os: osx
     language: generic
     env: PYTHON=python3 PIP=pip3 NUMBER="36" OS="darwin"

--- a/ci.py
+++ b/ci.py
@@ -56,7 +56,7 @@ def ci(python="python", codecov="codecov", coverage_file="coverage.xml"):
     wheel = [file for file in os.listdir("dist") if file.endswith((".whl", ".tar.gz"))][0]
     wheel = os.path.join("dist", wheel)
     print("Wheel file:", wheel)
-    return_code = run_command("{} -m pip install {}".format(python, wheel))
+    return_code = run_command("{} -m pip install --ignore-installed {}".format(python, wheel))
     if return_code != 0:
         print("Installation of wheel failed.")
         exit(return_code)

--- a/ci.py
+++ b/ci.py
@@ -54,6 +54,7 @@ def ci(python="python", codecov="codecov", coverage_file="coverage.xml"):
     print("Wheel file exists.")
     # Install the wheel file
     wheel = [file for file in os.listdir("dist") if file.endswith((".whl", ".tar.gz"))][0]
+    wheel = os.path.join("dist", wheel)
     print("Wheel file:", wheel)
     return_code = run_command("{} -m pip install {}".format(python, wheel))
     if return_code != 0:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     current_dir = os.path.dirname(__file__)
     dest_dir = os.path.join(current_dir, "ttkthemes", "tkimg")
 
-    if os.path.isdir(os.path.join(current_dir, "ttkthemes")):
+    if os.path.exists(os.path.join(current_dir, "tkimg")):
         # ttkthemes source is in the ttkthemes/ folder and tkimg needs to
         # be copied there
         if "sdist" not in sys.argv[1]:


### PR DESCRIPTION
This branch contains the fix of #26, as well as improved tests to check whether #26 has actually been fixed and to check if similar issues occur again. A small overview of the changes:

- Instead of the `ttkthemes` directory, the existence of the `tkimg` directory is checked. If `tkimg` is present as a directory in the same folder as `setup.py`, it is full copy of the repository and not an installable Python redistributable file.
- Improve the `ci.py` file in order to run the tests on the *installed* version of `ttkthemes` instead of the one as the cloned repository.
- Change the path finding for AppVeyor artifacts, this is unrelated but it would be nice if it works as then AppVeyor will upload the artifacts automatically to GitHub releases. The only way to check is by tagging a new release :smile: .

So, all in all, this contains the directory checking goodness implemented by @Akuli , as well as working source distributions.