### PR TITLE
Merge toplevel into master to implement #31

### DIFF
--- a/tests/test_themed_tk.py
+++ b/tests/test_themed_tk.py
@@ -3,7 +3,7 @@ Author: RedFantom
 License: GNU GPLv3
 Copyright (c) 2017-2018 RedFantom
 """
-from ttkthemes._tkinter import ttk
+from ttkthemes._tkinter import tk, ttk
 from ttkthemes.themed_tk import ThemedTk
 import unittest
 
@@ -41,3 +41,18 @@ class TestThemedTk(unittest.TestCase):
             tk.set_theme_advanced(theme, brightness=0.2, saturation=1.4, hue=1.8)
             tk.destroy()
         return
+
+    def test_toplevel_hook(self):
+        __init__toplevel = tk.Toplevel.__init__
+        self.tk.set_theme("black", True, False)
+        self.assertNotEqual(__init__toplevel, tk.Toplevel.__init__)
+        top = tk.Toplevel(self.tk)
+        color = ttk.Style(self.tk).lookup("TFrame", "background")
+        self.assertIsNotNone(color)
+        self.assertEqual(top.cget("background"), color)
+        top.destroy()
+
+    def test_tk_background(self):
+        self.tk.config(background="white")
+        self.tk.set_theme("black", False, True)
+        self.assertNotEqual(self.tk.cget("background"), "white")

--- a/ttkthemes/_utils.py
+++ b/ttkthemes/_utils.py
@@ -17,7 +17,7 @@ platforms = {
 @contextlib.contextmanager
 def temporary_chdir(new_dir):
     """
-    Like os.chdir(), but always restores the old working directory.
+    Like os.chdir(), but always restores the old working directory
 
     For example, code like this...
 

--- a/ttkthemes/_widget.py
+++ b/ttkthemes/_widget.py
@@ -8,9 +8,9 @@ import os
 from shutil import copytree, rmtree
 # Packages
 from PIL import Image, ImageEnhance
-import ttkthemes._imgops as imgops
 # Project Modules
-from ttkthemes import _utils as utils
+from . import _utils as utils
+from . import _imgops as imgops
 from ._tkinter import tk
 from ._utils import get_file_directory
 

--- a/ttkthemes/themed_tk.py
+++ b/ttkthemes/themed_tk.py
@@ -3,8 +3,8 @@ Author: RedFantom
 License: GNU GPLv3
 Copyright (c) 2017-2018 RedFantom
 """
+from ._tkinter import tk, ttk
 from ._widget import ThemedWidget
-from ._tkinter import tk
 
 
 class ThemedTk(tk.Tk, ThemedWidget):
@@ -16,7 +16,7 @@ class ThemedTk(tk.Tk, ThemedWidget):
     def __init__(self, *args, **kwargs):
         """
         :param theme: Theme to set upon initialization. If theme is not
-                      available, will fails silently.
+            available, will fails silently.
         """
         theme = kwargs.pop("theme", None)
         # Initialize as tk.Tk
@@ -26,3 +26,16 @@ class ThemedTk(tk.Tk, ThemedWidget):
         # Set initial theme
         if theme is not None and theme in self.get_themes():
             self.set_theme(theme)
+        self.__init__toplevel = tk.Toplevel.__init__
+
+    def set_theme(self, theme_name):
+        """Redirect the set_theme call to also set Tk background color"""
+        color = ttk.Style(self).lookup("TFrame", "background", default="white")
+        
+        def __toplevel__(*args, **kwargs):
+            kwargs.setdefault("background", color)
+            self.__init__toplevel(*args, **kwargs)
+
+        tk.Toplevel.__init__ = __toplevel__
+        ThemedWidget.set_theme(self, theme_name)
+        self.config(background=color)

--- a/ttkthemes/themed_tk.py
+++ b/ttkthemes/themed_tk.py
@@ -9,33 +9,54 @@ from ._widget import ThemedWidget
 
 class ThemedTk(tk.Tk, ThemedWidget):
     """
-    Tk child class that supports the themes supplied in this package.
+    Tk child class that supports the themes supplied in this package
+
     A theme can be set upon initialization or during runtime. Can be
-    used as a drop-in replacement for the normal Tk class.
+    used as a drop-in replacement for the normal Tk class. Additional
+    options:
+
+    - Toplevel background color
+      Hooks into the Toplevel.__init__ function to set a default window
+      background color in the options passed. The hook is not removed
+      after the window is destroyed, which is by design because creating
+      multiple Tk instances should not be done in the first place.
+
+    - Tk background color
+      Simply sets the background color of the Tkinter window to the
+      default TFrame background color specified by the theme.
     """
     def __init__(self, *args, **kwargs):
         """
         :param theme: Theme to set upon initialization. If theme is not
-            available, will fails silently.
+            available, fails silently.
+        :param toplevel: Control Toplevel background color option
+        :param background: Control Tk background color option
         """
         theme = kwargs.pop("theme", None)
+        toplevel = kwargs.pop("toplevel", False)
+        background = kwargs.pop("background", False)
         # Initialize as tk.Tk
         tk.Tk.__init__(self, *args, **kwargs)
         # Initialize as ThemedWidget
         ThemedWidget.__init__(self, self.tk)
         # Set initial theme
         if theme is not None and theme in self.get_themes():
-            self.set_theme(theme)
+            self.set_theme(theme, toplevel, background)
         self.__init__toplevel = tk.Toplevel.__init__
 
-    def set_theme(self, theme_name):
+    def set_theme(self, theme_name, toplevel=False, background=False):
         """Redirect the set_theme call to also set Tk background color"""
+        ThemedWidget.set_theme(self, theme_name)
         color = ttk.Style(self).lookup("TFrame", "background", default="white")
-        
+        if background is True:
+            self.config(background=color)
+        if toplevel is True:
+            self._setup_toplevel_hook(color)
+
+    def _setup_toplevel_hook(self, color):
+        """Setup Toplevel.__init__ hook for background color"""
         def __toplevel__(*args, **kwargs):
             kwargs.setdefault("background", color)
             self.__init__toplevel(*args, **kwargs)
 
         tk.Toplevel.__init__ = __toplevel__
-        ThemedWidget.set_theme(self, theme_name)
-        self.config(background=color)


### PR DESCRIPTION
The first of these two commits implements #31 by creating a hook for `Toplevel.__init__` so that the default background color of the `Toplevel` is set by default to the `background` color of `TFrame`.

The second commit implements the option to turn off this hook and sets it not to be enabled by default. In addition, an option for changing the background color of the `Tk` window is added.

Note the following properties of the hook:
- It does not change `Toplevel.__init__` arguments or kwargs
- It only sets a default value for the `background` kwarg, code that specifies this background color will always override it
- It is **not** removed after the `Tk` instance is destroyed, this is by design
- It is disabled by default

Note the following properties of the background color option:
- It always overrides  the color of the window if it is already set
- It is disabled by default

Both options are covered by unittests in the `tests/test_themed_tk.py` file.

If the theme does not explicitly specify a color for the `background` of the `TFrame` widget (even though I'm pretty sure they all do), `white` is selected as the default color.