### PR TITLE
Merge docs into master to include wiki information

### DIFF
--- a/docs/classes.rst
+++ b/docs/classes.rst
@@ -1,5 +1,5 @@
-Documentation
-=============
+Reference
+=========
 
 .. autoclass:: ttkthemes.themed_style.ThemedStyle
    :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,8 @@ by RedFantom and created by various authors.
     classes
     example
     themes
+    theming
+    licenses
     installation
 
 License

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ by RedFantom and created by various authors.
     authors
     classes
     example
+    themes
     installation
 
 License

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,7 +10,7 @@ Installation from PyPI is easiest. Simply use ``pip`` to fetch the
 package and install it:
 
 .. code-block:: python
-
+   python3 -m pip install -U setuptools wheel
    python3 -m pip install ttkthemes
 
 There is a single installation option available for ``ttkthemes``. In
@@ -19,11 +19,15 @@ an extension is required under Python 2 and some earlier distributions
 of Python 3. Simply install the extension with ``pip`` as well.
 
 .. code-block:: python
-
+   python3 -m pip install -U setuptools wheel
    python3 -m pip install ttkthemes[tkimg]
 
 This option installs the separate package ``tkimg``, for which more
 information is available from here_.
+
+In some cases, it is required to update ``setuptools`` in order to
+install ``ttkthemes``. It is not known which version of ``setuptools``
+is exactly required at this time.
 
 .. _here : https://www.github.com/RedFantom/python-tkimg
 

--- a/docs/licenses.rst
+++ b/docs/licenses.rst
@@ -1,0 +1,9 @@
+Licenses
+========
+
+The themes included in the ``ttkthemes`` package have been released
+under various different licenses, including the BSD-2-clause-like Tcl
+License, GNU GPLv2+ and GNU GPLv3. Note that the only license under
+which all themes are available together is GNU GPLv3. Most of the code
+is available under GNU GPLv3 only. If code is available under any  other
+license, it is indicated in the specific files and folders.

--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -1,0 +1,24 @@
+Themes
+======
+
+``ttkthemes`` includes a wide variety of different themes, and there is
+always room for more themes, no matter how ugly or obscure! Even though
+some themes may not be used in practice, the original goal of the
+project has not been forgotten: To gather and preserve *all* themes.
+
+.. |aquativo| image:: https://imgur.com/RUH48LL.png
+.. |arc| image:: https://imgur.com/nmjPIYl.png
+.. |black| image:: https://imgur.com/5vs2aw4
+.. |blue| image:: https://imgur.com/vA5jBiA.png
+.. |clearlooks| image:: https://imgur.com/ujVt54x.png
+.. |elegance| image:: https://imgur.com/nGlluzL.png
+.. |equilux| image:: https://imgur.com/UahDaHl.png
+.. |itft1| image:: https://imgur.com/WH3fkiN.png
+.. |keramik| image:: https://imgur.com/ZW2Xw1A.png
+.. |keramik_alt| image:: https://imgur.com/EZzEYQ1.png
+.. |kroc| image:: https://imgur.com/1SrLhKL.png
+.. |plastik| image:: https://imgur.com/21PjNzW.png
+.. |radiance| image:: https://imgur.com/CZczNBz.png
+.. |smog| image:: https://imgur.com/DFmThbK.png
+.. |ubuntu| image:: https://imgur.com/0WlZwfD.png
+.. |winxpblue| image:: https://imgur.com/3StdivF.png

--- a/docs/themes.rst
+++ b/docs/themes.rst
@@ -6,6 +6,116 @@ always room for more themes, no matter how ugly or obscure! Even though
 some themes may not be used in practice, the original goal of the
 project has not been forgotten: To gather and preserve *all* themes.
 
+Aquativo
+--------
+|aquativo|
+
+An Apple-style like theme by Pat Thoyts, created in 2004. The original site is listed to
+be `http://www.fewt.com`, but you will only be able to view this site using the
+Internet archive's Wayback machine. It appears the theme is related to the Ubuntu-based
+Linux distribution _Fuduntu.
+
+Arc
+---
+|arc|
+
+The newest theme of the bunch. Being created by Sergei Golovan in 2015 this theme
+requires Tk 8.6.0 in order to load. This is because the theme uses PNG images with
+transparency, making for a blue-tinted modern look and feel.
+
+Black
+-----
+|black|
+
+A simple yet quite popular theme, as it is very consistent in its use of
+dark colors in all widgets. Created by Mats Bengtsson in 2007.
+
+Blue
+----
+|blue|
+
+A theme that does live up to its name. This theme will burn your eyes out being so bright.
+Everything is blue, though in some widgets there is a nice color gradient. This theme was
+also created by Pat Thoyts in 2004.
+
+Clearlooks
+----------
+|clearlooks|
+
+This theme was created by the Tcl/Tk developers team as a demo for what bitmap themes can do.
+The light tints move toward peach colors, giving this theme a feminine look. It still looks
+sleek and modern, and wouldn't be a bad choice. Just as with all themes though, the corners
+are rounded.
+
+Elegance
+--------
+|elegance|
+
+A theme that appears to be created by the Tcl/Tk developers team. While attempts to
+tracing its exact origin have been unsuccessful so far, this theme was probably created
+around 2008. The theme can be found here_, but no author is listed.
+
+Equilux
+-------
+|equilux|
+
+Originally equilux_ is a GTK3 theme.
+
+ITFT1
+-----
+|itft1|
+
+Keramik
+-------
+|keramik| |keramik_alt|
+
+These two themes use a single file ``keramik.tcl`` and the differences between them are fairly
+limited. Originally developed by Pat Thoyts in 2004. These themes look the opposite of modern.
+They are futuristic, but in a bit of a wrong way. Keramic_alt uses a different color scrollbar
+element, namely silver instead of dark blue.
+
+Kroc
+----
+|kroc|
+
+This orange theme by David Zolli is busy on the eyes and has a wood-like grain in the Button
+widgets. Not a recommended choice for modern UI development.
+
+Plastik
+-------
+|plastik|
+
+A nice looking theme created by Pat Thoyts in 2005. While not bolstering the most distinctive
+features, it looks quite modern. Performance suffers heavily though, this is resolved by
+commenting out line 193 of the ``plastik.tcl`` file. The theme changes only slightly because
+of this change, but native performance is restored.
+
+Radiance (Ubuntu)
+-----------------
+|radiance| |ubuntu|
+
+A theme that was developed by the Tcl/Tk developers team. This theme, as the name suggests,
+boasts the native look of Ubuntu's radiance theme, making for a good choice  when targeting
+this platform. Large Progressbar widgets (namely in height) may look a bit mutated, so try
+sticking to the normal Progressbar height.
+
+Theme ``ubuntu`` is equal to radiance, except is uses transparent elements in place of some
+white areas. Therefore, it looks a bit better when PNG-themes are available.
+
+Smog
+----
+|smog|
+
+winxpblue
+---------
+|winxpblue|
+
+A theme that tries to imitate the Windows XP look and feel created by Pat Thoyts in 2004. Not
+recommended, even for Windows XP applications.
+
+.. _Fuduntu: https://en.wikipedia.org/wiki/Fuduntu
+.. _here: https://www.gnome-look.org/content/show.php/Blue+Elegance+Light?content=164806
+.. _equilux: https://github.com/ddnexus/equilux-theme
 .. |aquativo| image:: https://imgur.com/RUH48LL.png
 .. |arc| image:: https://imgur.com/nmjPIYl.png
 .. |black| image:: https://imgur.com/5vs2aw4

--- a/docs/theming.rst
+++ b/docs/theming.rst
@@ -1,0 +1,106 @@
+Theming
+========
+
+``ttkthemes`` supports the creation of custom themes based upon static
+themes during runtime. This is called dynamic theming. The functions to
+create dynamic themes are implemented in the ``ThemedWidget`` class.
+PNG-based theme support is required to apply a dynamic theme.
+
+Choosing a theme
+----------------
+In order to use dynamic theming, you must first choose a theme to base
+your new theme on. The supported themes for dynamic themes are all
+pixmap themes that use files (and not a packed archive with files)
+directly to load pixmaps. An up-to-date ``list`` of supported pixmap
+themes may be found in the ``pixmap_themes`` class attribute of any
+``ThemedWidget`` instance (such as ``ThemedTk`` or ``ThemedStyle``). At
+the time of writing, the following list is available:
+
+.. code-block:: python
+
+    pixmap_themes = [
+       "arc",
+       "blue",
+       "clearlooks",
+       "elegance",
+       "kroc",
+       "plastik",
+       "radiance",
+       "winxpblue"
+    ]
+
+It is recommended to choose a theme with noticeable colors for the best
+results. ``radiance`` and ``blue`` have proven to be quite suitable for
+this purpose. In order to use ``blue``, it is recommended to also modify
+the ``background`` colors of all widgets you plan to use, as the
+theme colors are not changed during the operations.
+
+Note that while being a pixmap theme, ``equilux`` is not included
+because using dynamic theming with that theme results in severe
+conversion artifacts.
+
+Modifying a theme
+-----------------
+In order to load an advanced theme, the following function is provided
+within any ``ThemedWidget``:
+.. code-block:: python
+
+    def set_theme_advanced(
+        self, theme_name, brightness=1.0, saturation=1.0, hue=1.0,
+        preserve_transparency=True, output_dir=None, advanced_name="advanced"
+    )
+
+As you might be able to deduce from the function definition, various
+parameters can be used to modify the pixmaps of the theme you choose:
+
+- ``theme_name``: The name of a valid pixmap theme to use for
+  modification
+- ``brightness``: A modifier that is passed on to a
+  :obj:`PIL.ImageEnhance.Brightness enhancer`. Values between 0.0 and
+  2.0 are expected.
+- ``saturation``: A modifier that is passed on to a
+  :obj:`PIL.ImageEnhance.Color` enhancer. Values between 0.0 and 2.0 are
+  expected.
+- ``hue``: A modifier that is used for the
+  :obj:`ttkthemes._utils.shift_hue` function. Shifts the hue of an image
+  by a certain amount. Note that the hue is the hue shift. Values
+  between 0.0 and 2.0 are expected.
+- ``preserve_transparency``: When set to :obj:`True`, all resulting
+  black pixels will be set to transparent. This is only required when
+  modifying the hue of an image. During the conversion from RGBA to HSV
+  image format, transparency is lost to black pixels, resulting in ugly
+  black patches in images if not reversed.
+- ``output_dir``: Directory (to which write access is available) in
+  which the new theme files should be placed. By default, a temporary
+  directory is used provided by :obj:`tempfile`. Note that on most
+  systems, this directory is cleared upon reboot.
+- ``advanced_name``: Name of the theme to generate. You can combine this
+  with an ``output_dir`` parameter to actually create a custom theme
+  that you can install on other machines as well. NOTE THAT IT IS
+  REQUIRED TO USE A DIFFERENT NAME EACH TIME IF YOU SET THE ADVANCED
+  THEME FOR A SINGLE TK INTERPRETER INSTANCE MULTIPLE TIMES.
+
+Examples
+--------
+Some examples of what you can create using this function:
+
+|radiance|
+
+A modified radiance theme. The hue is changed so all originally orange
+features are a bright green.
+
+|arc|
+
+A modified arc theme. The hue is changed as well as the brightness,
+though the latter only very slightly.
+
+Notes
+-----
+Note that the theme is generated during runtime, when the function
+``set_theme_advanced`` is called. When the function is called, rather
+resource-expensive operations upon tens of images are performed, as well
+as disk I/O and loading all images into memory may cause a spike in
+memory usage, even though it is not all that much on most modern PCs.
+
+.. |radiance| image:: https://user-images.githubusercontent.com/15170036/35413951-5422cd4a-0221-11e8-96c5-a21154ed2b31.png
+.. |arc| image:: https://user-images.githubusercontent.com/15170036/35414048-a2af1ff4-0221-11e8-9462-e9733f91fb34.png

--- a/docs/theming.rst
+++ b/docs/theming.rst
@@ -43,6 +43,7 @@ Modifying a theme
 -----------------
 In order to load an advanced theme, the following function is provided
 within any ``ThemedWidget``:
+
 .. code-block:: python
 
     def set_theme_advanced(


### PR DESCRIPTION
The goal of this PR is to unify all the information on the `ttkthemes` package in the ReadTheDocs of `ttkthemes`. Currently, some useful information is still provided in the Wiki, and this creates an undesirable split to two sources of information: ReadTheDocs and the GitHub Wiki.

After the merging of this PR, the Wiki can be disabled on this repository.