### PR TITLE
Merge themebg into master to fix background option

### DIFF
--- a/example.py
+++ b/example.py
@@ -23,7 +23,7 @@ class Example(ThemedTk):
     Example that is used to create screenshots for new themes.
     """
     def __init__(self):
-        ThemedTk.__init__(self)
+        ThemedTk.__init__(self, themebg=True)
         # Create widgets
         self.menu = tk.Menu(self, tearoff=False)
         self.sub_menu = tk.Menu(self.menu, tearoff=False)
@@ -101,5 +101,5 @@ class Example(ThemedTk):
 
 if __name__ == '__main__':
     example = Example()
-    example.set_theme("scidblue")
+    example.set_theme("equilux")
     example.mainloop()

--- a/tests/test_themed_tk.py
+++ b/tests/test_themed_tk.py
@@ -55,3 +55,26 @@ class TestThemedTk(unittest.TestCase):
         self.tk.config(background="white")
         self.tk.set_theme("black", False, True)
         self.assertNotEqual(self.tk.cget("background"), "white")
+
+    def test_config_cget(self):
+        self.tk.config(theme="equilux")
+        self.assertEqual(self.tk.cget("theme"), self.tk.current_theme)
+        self.assertEqual(self.tk.cget("theme"), "equilux")
+
+        self.tk.config(themebg=True)
+        self.assertTrue(self.tk.cget("themebg"))
+        before = self.tk.cget("bg")
+        self.tk.config(themebg=False)
+        self.assertFalse(self.tk.cget("themebg"))
+        after = self.tk.cget("bg")
+        self.assertNotEqual(before, after)
+
+        self.tk.config(toplevel=False)
+        self.assertFalse(self.tk.cget("toplevel"))
+        orig = tk.Toplevel.__init__
+        self.tk.config(toplevel=True)
+        self.assertTrue(self.tk.cget("toplevel"))
+        self.assertNotEqual(orig, tk.Toplevel.__init__)
+
+        self.tk.configure(toplevel=False)
+        self.assertEqual(tk.Toplevel.__init__, orig)

--- a/tests/test_themed_tk.py
+++ b/tests/test_themed_tk.py
@@ -66,13 +66,13 @@ class TestThemedTk(unittest.TestCase):
         before = self.tk.cget("bg")
         self.tk.config(themebg=False)
         self.assertFalse(self.tk.cget("themebg"))
-        after = self.tk.cget("bg")
+        after = self.tk["bg"]
         self.assertNotEqual(before, after)
 
         self.tk.config(toplevel=False)
         self.assertFalse(self.tk.cget("toplevel"))
         orig = tk.Toplevel.__init__
-        self.tk.config(toplevel=True)
+        self.tk["toplevel"] = True
         self.assertTrue(self.tk.cget("toplevel"))
         self.assertNotEqual(orig, tk.Toplevel.__init__)
 

--- a/ttkthemes/_widget.py
+++ b/ttkthemes/_widget.py
@@ -106,6 +106,11 @@ class ThemedWidget(object):
         """Property alias of get_themes()"""
         return self.get_themes()
 
+    @property
+    def current_theme(self):
+        """Property to get the currently enabled theme"""
+        return self.tk.eval("return $ttk::currentTheme")
+
     def set_theme_advanced(self, theme_name, brightness=1.0,
                            saturation=1.0, hue=1.0,
                            preserve_transparency=True, output_dir=None,

--- a/ttkthemes/themed_tk.py
+++ b/ttkthemes/themed_tk.py
@@ -77,17 +77,22 @@ class ThemedTk(tk.Tk, ThemedWidget):
 
     def config(self, kw=None, **kwargs):
         """Configure redirect to support additional options"""
-        background = kwargs.pop("themebg", self._themebg)
+        themebg = kwargs.pop("themebg", self._themebg)
         toplevel = kwargs.pop("toplevel", self._toplevel)
         theme = kwargs.pop("theme", self.current_theme)
         color = self._get_bg_color()
-        if background != self._themebg:
-            self.configure(bg="white")
+        if themebg != self._themebg:
+            if themebg is False:
+                self.configure(bg="white")
+            else:
+                self.configure(bg=color)
+            self._themebg = themebg
         if toplevel != self._toplevel:
             if toplevel is True:
                 self._setup_toplevel_hook(color)
             else:
                 tk.Toplevel.__init__ = self.__init__toplevel
+            self._toplevel = toplevel
         if theme != self.current_theme:
             self.set_theme(theme)
         return tk.Tk.config(self, kw, **kwargs)

--- a/ttkthemes/themed_tk.py
+++ b/ttkthemes/themed_tk.py
@@ -15,13 +15,18 @@ class ThemedTk(tk.Tk, ThemedWidget):
     used as a drop-in replacement for the normal Tk class. Additional
     options:
 
-    - Toplevel background color:
+    - Initial theme ``theme``:
+      Sets the initial theme to the theme specified. If the theme is
+      not available, fails silenty (there is no indication that the
+      theme is not set other than
+
+    - Toplevel background color ``toplevel``:
       Hooks into the Toplevel.__init__ function to set a default window
       background color in the options passed. The hook is not removed
       after the window is destroyed, which is by design because creating
       multiple Tk instances should not be done in the first place.
 
-    - Tk background color:
+    - Tk background color ``themebg``:
       Simply sets the background color of the Tkinter window to the
       default TFrame background color specified by the theme.
     """
@@ -34,8 +39,8 @@ class ThemedTk(tk.Tk, ThemedWidget):
         :param background: Control Tk background color option
         """
         theme = kwargs.pop("theme", None)
-        toplevel = kwargs.pop("toplevel", False)
-        background = kwargs.pop("background", False)
+        self._toplevel = kwargs.pop("toplevel", None)
+        self._themebg = kwargs.pop("themebg", None)
         gif_override = kwargs.pop("gif_override", False)
         # Initialize as tk.Tk
         tk.Tk.__init__(self, *args, **kwargs)
@@ -43,17 +48,24 @@ class ThemedTk(tk.Tk, ThemedWidget):
         ThemedWidget.__init__(self, self.tk, gif_override)
         # Set initial theme
         if theme is not None and theme in self.get_themes():
-            self.set_theme(theme, toplevel, background)
+            self.set_theme(theme, self._toplevel, self._themebg)
         self.__init__toplevel = tk.Toplevel.__init__
 
-    def set_theme(self, theme_name, toplevel=False, background=False):
+    def set_theme(self, theme_name, toplevel=None, themebg=None):
         """Redirect the set_theme call to also set Tk background color"""
+        if self._toplevel is not None and toplevel is None:
+            toplevel = self._toplevel
+        if self._themebg is not None and themebg is None:
+            themebg = self._themebg
         ThemedWidget.set_theme(self, theme_name)
-        color = ttk.Style(self).lookup("TFrame", "background", default="white")
-        if background is True:
+        color = self._get_bg_color()
+        if themebg is True:
             self.config(background=color)
         if toplevel is True:
             self._setup_toplevel_hook(color)
+
+    def _get_bg_color(self):
+        return ttk.Style(self).lookup("TFrame", "background", default="white")
 
     def _setup_toplevel_hook(self, color):
         """Setup Toplevel.__init__ hook for background color"""
@@ -62,3 +74,33 @@ class ThemedTk(tk.Tk, ThemedWidget):
             self.__init__toplevel(*args, **kwargs)
 
         tk.Toplevel.__init__ = __toplevel__
+
+    def config(self, kw=None, **kwargs):
+        """Configure redirect to support additional options"""
+        background = kwargs.pop("themebg", self._themebg)
+        toplevel = kwargs.pop("toplevel", self._toplevel)
+        theme = kwargs.pop("theme", self.current_theme)
+        color = self._get_bg_color()
+        if background != self._themebg:
+            self.configure(bg="white")
+        if toplevel != self._toplevel:
+            if toplevel is True:
+                self._setup_toplevel_hook(color)
+            else:
+                tk.Toplevel.__init__ = self.__init__toplevel
+        if theme != self.current_theme:
+            self.set_theme(theme)
+        return tk.Tk.config(self, kw, **kwargs)
+
+    def configure(self, kw=None, **kwargs):
+        return self.config(kw, **kwargs)
+
+    def cget(self, k):
+        """cget redirect to support additional options"""
+        if k == "themebg":
+            return self._themebg
+        elif k == "toplevel":
+            return self._toplevel
+        elif k == "theme":
+            return self.current_theme
+        return tk.Tk.cget(self, k)

--- a/ttkthemes/themed_tk.py
+++ b/ttkthemes/themed_tk.py
@@ -29,6 +29,11 @@ class ThemedTk(tk.Tk, ThemedWidget):
     - Tk background color ``themebg``:
       Simply sets the background color of the Tkinter window to the
       default TFrame background color specified by the theme.
+
+    - GIF theme override ``gif_override``:
+      Forces ttkthemes to load the GIF version of themes that also
+      provide a PNG version even if the PNG version can be loaded. Can
+      only be set at object initialization.
     """
 
     def __init__(self, *args, **kwargs):
@@ -76,7 +81,7 @@ class ThemedTk(tk.Tk, ThemedWidget):
         tk.Toplevel.__init__ = __toplevel__
 
     def config(self, kw=None, **kwargs):
-        """Configure redirect to support additional options"""
+        """configure redirect to support additional options"""
         themebg = kwargs.pop("themebg", self._themebg)
         toplevel = kwargs.pop("toplevel", self._toplevel)
         theme = kwargs.pop("theme", self.current_theme)
@@ -97,9 +102,6 @@ class ThemedTk(tk.Tk, ThemedWidget):
             self.set_theme(theme)
         return tk.Tk.config(self, kw, **kwargs)
 
-    def configure(self, kw=None, **kwargs):
-        return self.config(kw, **kwargs)
-
     def cget(self, k):
         """cget redirect to support additional options"""
         if k == "themebg":
@@ -109,3 +111,12 @@ class ThemedTk(tk.Tk, ThemedWidget):
         elif k == "theme":
             return self.current_theme
         return tk.Tk.cget(self, k)
+
+    def configure(self, kw=None, **kwargs):
+        return self.config(kw, **kwargs)
+
+    def __getitem__(self, k):
+        return self.cget(k)
+
+    def __setitem__(self, k, v):
+        return self.config(**{k: v})


### PR DESCRIPTION
![equilux_themebg](https://user-images.githubusercontent.com/15170036/53820529-3df51300-3f6c-11e9-96e4-b84e503381c5.png)
As shown in the image, the commits in this branch fix the usage of the `background` kwarg (renaming it to `themebg` to avoid confusion with the default `background` kwarg of `Tk`). In addition, the commits implement modified versions of the `config`, `configure` and `cget` functions to set and retrieve options. The custom options of `ThemedTk` can be set upon initialization, unlike the other options of `Tk`, but now also during run-time.
