### PR TITLE
Merge themebg into master to improve behaviour and documentation for #50

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ environment:
     - PYTHON: "C:\\PYTHON36-x64"
 build: off
 before_test:
-  - "%PYTHON%\\python.exe -m pip install --upgrade pip"
+  - "%PYTHON%\\python.exe -m pip install --upgrade pip==9.0.3"
 test_script:
   - "%PYTHON%\\python.exe ci.py"
 artifacts:

--- a/example.py
+++ b/example.py
@@ -7,7 +7,6 @@ import os
 import sys
 if sys.version_info.major == 3:
     import tkinter as tk
-    from tkinter import Tk as ThemedTk
     from tkinter import ttk
 else:
     import Tkinter as tk

--- a/ttkthemes/themed_tk.py
+++ b/ttkthemes/themed_tk.py
@@ -55,8 +55,6 @@ class ThemedTk(tk.Tk, ThemedWidget):
         background = kwargs.pop("background", None)
         if isinstance(background, bool):
             self._themebg = self._themebg or background
-        else:
-            kwargs["background"] = background
         gif_override = kwargs.pop("gif_override", False)
         # Initialize as tk.Tk
         tk.Tk.__init__(self, *args, **kwargs)

--- a/ttkthemes/themed_tk.py
+++ b/ttkthemes/themed_tk.py
@@ -17,8 +17,8 @@ class ThemedTk(tk.Tk, ThemedWidget):
 
     - Initial theme ``theme``:
       Sets the initial theme to the theme specified. If the theme is
-      not available, fails silenty (there is no indication that the
-      theme is not set other than
+      not available, fails silently (there is no indication that the
+      theme is not set other than it not appearing to the user).
 
     - Toplevel background color ``toplevel``:
       Hooks into the Toplevel.__init__ function to set a default window
@@ -27,25 +27,36 @@ class ThemedTk(tk.Tk, ThemedWidget):
       multiple Tk instances should not be done in the first place.
 
     - Tk background color ``themebg``:
-      Simply sets the background color of the Tkinter window to the
-      default TFrame background color specified by the theme.
+      Set the default background color of a Tk window to the default
+      theme background color. For example: The background of windows
+      may take on a dark color for dark themes. Backwards-compatible
+      with the ``background`` keyword argument of v2.3.0 and earlier.
 
     - GIF theme override ``gif_override``:
       Forces ttkthemes to load the GIF version of themes that also
       provide a PNG version even if the PNG version can be loaded. Can
-      only be set at object initialization.
+      only be set at object initialization. GIF themes may provide a
+      higher UI performance than other themes.
     """
 
     def __init__(self, *args, **kwargs):
         """
         :param theme: Theme to set upon initialization. If theme is not
             available, fails silently.
-        :param toplevel: Control Toplevel background color option
-        :param background: Control Tk background color option
+        :param toplevel: Control Toplevel background color option,
+            see class documentation for details.
+        :param themebg: Control Tk background color option, see
+            class documentation for details.
         """
         theme = kwargs.pop("theme", None)
         self._toplevel = kwargs.pop("toplevel", None)
         self._themebg = kwargs.pop("themebg", None)
+        # Backwards compatibility with ttkthemes v2.3.0
+        background = kwargs.pop("background", None)
+        if isinstance(background, bool):
+            self._themebg = self._themebg or background
+        else:
+            kwargs["background"] = background
         gif_override = kwargs.pop("gif_override", False)
         # Initialize as tk.Tk
         tk.Tk.__init__(self, *args, **kwargs)


### PR DESCRIPTION
The commits in this branch improve the documentation and behaviour of the ``themebg`` background option as intended in #58 while retaining backwards compatibility with version `2.3.0`'s `background` keyword argument.